### PR TITLE
Remove GC randomization from builds

### DIFF
--- a/build_randomization.rb
+++ b/build_randomization.rb
@@ -50,7 +50,7 @@ include Log4r
 RANDOM_CHOICES = {
   'tests.jvm.argline' => [
                 {:choices => ['-server'], :method => 'get_random_one'},
-                {:choices => ['-XX:+UseConcMarkSweepGC', '-XX:+UseParallelGC', '-XX:+UseSerialGC', '-XX:+UseG1GC'], :method => 'get_random_one'},
+                {:choices => ['-XX:+UseConcMarkSweepGC'], :method => 'get_random_one'},
                 {:choices => ['-XX:+UseCompressedOops', '-XX:-UseCompressedOops'], :method => 'get_random_one'},
                 {:choices => ['-XX:+AggressiveOpts'], :method => 'get_50_percent'}
                ],


### PR DESCRIPTION
This will prevent issues with conflicting collector configurations now that the upstream mechanism for handling GC options has changed.

@mrsolo will this get updated on the old build slave nodes automatically via the [jenkins_scripts_update_new_test job](http://build-us-00.elastic.co/job/jenkins_scripts_update_new_test/), or will I need to jump on the nodes manually to pull in the update?

cc: @jasontedor 

Resolves elastic/infra#1028